### PR TITLE
Add clarification on differences of `is.convert`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,3 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
-
-[*.md]
-trim_trailing_whitespace = false

--- a/.editorconfig
+++ b/.editorconfig
@@ -7,3 +7,6 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/readme.md
+++ b/readme.md
@@ -90,9 +90,8 @@ Create a test function from `test`, that can later be called with a `node`,
 Useful if you’re going to test many nodes, for example when creating a utility
 where something else passes an is-compatible test.
 
-The function created with `is.convert` does not validate any of the parameters
-with which it is called.  
-*Invalid values for `node`, `index` or `parent` will pass silently.*
+The created function is slightly faster because it expects valid input only.
+Therefore, passing invalid input, yields unexpected results.
 
 Can also be accessed with `require('unist-util-is/convert')`.
 

--- a/readme.md
+++ b/readme.md
@@ -90,6 +90,9 @@ Create a test function from `test`, that can later be called with a `node`,
 Useful if you’re going to test many nodes, for example when creating a utility
 where something else passes an is-compatible test.
 
+_The function created with `is.convert` does not validate any of the parameters
+with which it is called. Invalid values for `node`, `index` or `parent` will pass silently._
+
 Can also be accessed with `require('unist-util-is/convert')`.
 
 For example:

--- a/readme.md
+++ b/readme.md
@@ -90,8 +90,9 @@ Create a test function from `test`, that can later be called with a `node`,
 Useful if you’re going to test many nodes, for example when creating a utility
 where something else passes an is-compatible test.
 
-_The function created with `is.convert` does not validate any of the parameters
-with which it is called. Invalid values for `node`, `index` or `parent` will pass silently._
+The function created with `is.convert` does not validate any of the parameters
+with which it is called.  
+*Invalid values for `node`, `index` or `parent` will pass silently.*
 
 Can also be accessed with `require('unist-util-is/convert')`.
 


### PR DESCRIPTION
Make it clear that is.convert does not validate the parameters passed to the
created function.
Addresses #12 

<!--

Read the [contributing guidelines](https://github.com/syntax-tree/.github/blob/master/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://github.com/syntax-tree/.github/blob/master/support.md
https://github.com/syntax-tree/.github/blob/master/contributing.md
-->
