### PR TITLE
Add `@types/unist` to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,9 @@
     "index.d.ts",
     "index.js"
   ],
+  "dependencies": {
+    "@types/unist": "^2.0.0"
+  },
   "devDependencies": {
     "@types/lodash": "^4.0.0",
     "@types/mdast": "^3.0.0",


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

`unist-util-is` directly references the `unist` types (for example [here](https://github.com/syntax-tree/unist-util-is/blob/main/lib/index.js#L2-L3)), so it should list it as a dependency. Failing that, loose package managers like npm may generate incorrect hoisting, and strict package managers like Yarn or pnpm may cause TS to fail to resolve the dependency.

Seems related to https://github.com/syntax-tree/unist-util-is/issues/14

Fixes the following errors:

```
unist-util-is/index.d.ts(5,23): error TS2307: Cannot find module 'unist' or its corresponding type declarations.
unist-util-is/index.d.ts(8,23): error TS2307: Cannot find module 'unist' or its corresponding type declarations.
unist-util-is/index.d.ts(11,23): error TS2307: Cannot find module 'unist' or its corresponding type declarations.
unist-util-is/lib/index.d.ts(89,25): error TS2307: Cannot find module 'unist' or its corresponding type declarations.
unist-util-is/lib/index.d.ts(91,16): error TS2307: Cannot find module 'unist' or its corresponding type declarations.
unist-util-is/lib/index.d.ts(100,27): error TS2307: Cannot find module 'unist' or its corresponding type declarations.
unist-util-is/lib/index.d.ts(102,16): error TS2307: Cannot find module 'unist' or its corresponding type declarations.
unist-util-is/lib/index.d.ts(143,23): error TS2307: Cannot find module 'unist' or its corresponding type declarations.
unist-util-is/lib/index.d.ts(148,27): error TS2307: Cannot find module 'unist' or its corresponding type declarations.
unist-util-is/lib/index.d.ts(149,29): error TS2307: Cannot find module 'unist' or its corresponding type declarations.
unist-util-is/lib/index.d.ts(174,23): error TS2307: Cannot find module 'unist' or its corresponding type declarations.
unist-util-is/lib/index.d.ts(184,23): error TS2307: Cannot find module 'unist' or its corresponding type declarations.
unist-util-is/lib/index.d.ts(202,23): error TS2307: Cannot find module 'unist' or its corresponding type declarations.
```

<!--do not edit: pr-->
